### PR TITLE
Fix CodeQL unused-variable false positives by using move closures

### DIFF
--- a/app/src-tauri/src/core/accounts.rs
+++ b/app/src-tauri/src/core/accounts.rs
@@ -154,7 +154,7 @@ pub fn update_account_db(
     name: String,
     currency: Option<String>,
 ) -> Result<Account, String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let name_trimmed = name.trim().to_string();
         if name_trimmed.is_empty() {
             return Err("Account name cannot be empty or whitespace-only".to_string());
@@ -206,7 +206,7 @@ pub fn update_account_db(
 
 /// Deletes an account and all of its associated transactions.
 pub fn delete_account_db(db_path: &PathBuf, id: i32) -> Result<(), String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let mut conn = Connection::open(db_path).map_err(|e| e.to_string())?;
 
         let tx = conn.transaction().map_err(|e| e.to_string())?;

--- a/app/src-tauri/src/core/llm.rs
+++ b/app/src-tauri/src/core/llm.rs
@@ -272,8 +272,9 @@ pub fn create_conversation_db(db_path: &PathBuf, title: String) -> Result<Conver
 #[tauri::command]
 pub fn delete_conversation(app_handle: AppHandle, conversation_id: i64) -> Result<(), String> {
     let db_path = db_init::get_db_path(&app_handle)?;
-    db_init::with_db_lock(&db_path, || {
-        let conn = Connection::open(&db_path).map_err(|e| e.to_string())?;
+    let db_ref = db_path.as_path();
+    db_init::with_db_lock(db_ref, move || {
+        let conn = Connection::open(db_ref).map_err(|e| e.to_string())?;
         conn.execute("PRAGMA foreign_keys = ON", [])
             .map_err(|e| e.to_string())?;
         conn.execute(
@@ -293,8 +294,9 @@ pub fn rename_conversation(
     title: String,
 ) -> Result<(), String> {
     let db_path = db_init::get_db_path(&app_handle)?;
-    db_init::with_db_lock(&db_path, || {
-        let conn = Connection::open(&db_path).map_err(|e| e.to_string())?;
+    let db_ref = db_path.as_path();
+    db_init::with_db_lock(db_ref, move || {
+        let conn = Connection::open(db_ref).map_err(|e| e.to_string())?;
         let now = Utc::now().to_rfc3339();
         conn.execute(
             "UPDATE chat_conversations SET title = ?1, updated_at = ?2 WHERE id = ?3",
@@ -320,7 +322,7 @@ pub fn get_conversation_messages_db(
     db_path: &PathBuf,
     conversation_id: i64,
 ) -> Result<Vec<ChatMessage>, String> {
-    db_init::with_db_lock(db_path, || {
+    db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
         let mut stmt = conn
             .prepare(
@@ -356,7 +358,7 @@ fn save_message_db(
     tool_call_id: Option<&str>,
     thinking: Option<&str>,
 ) -> Result<i64, String> {
-    db_init::with_db_lock(db_path, || {
+    db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
         let now = Utc::now().to_rfc3339();
         conn.execute(

--- a/app/src-tauri/src/core/markets.rs
+++ b/app/src-tauri/src/core/markets.rs
@@ -502,7 +502,7 @@ pub fn get_daily_stock_prices_from_path(
     db_path: &std::path::Path,
     ticker: String,
 ) -> Result<Vec<DailyPrice>, String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
 
         let mut stmt = conn

--- a/app/src-tauri/src/core/rules.rs
+++ b/app/src-tauri/src/core/rules.rs
@@ -249,7 +249,7 @@ pub fn update_rule_db(db_path: &PathBuf, params: UpdateRuleDbParams) -> Result<(
 
 /// Deletes a rule by ID.
 pub fn delete_rule_db(db_path: &PathBuf, id: i32) -> Result<(), String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
 
         conn.execute("DELETE FROM rules WHERE id = ?1", params![id])

--- a/app/src-tauri/src/core/scheduled.rs
+++ b/app/src-tauri/src/core/scheduled.rs
@@ -524,7 +524,7 @@ pub fn update_scheduled_transaction_db(
 
 /// Deletes a scheduled transaction by ID.
 pub fn delete_scheduled_transaction_db(db_path: &PathBuf, id: i32) -> Result<(), String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
         conn.execute(
             "DELETE FROM scheduled_transactions WHERE id = ?1",
@@ -631,7 +631,7 @@ pub fn apply_scheduled_occurrence_db(
     scheduled_tx_id: i32,
     apply_date: &str,
 ) -> Result<(), String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
 
         // Fetch the scheduled transaction
@@ -699,7 +699,7 @@ pub fn skip_scheduled_occurrence_db(
     scheduled_tx_id: i32,
     skip_date: &str,
 ) -> Result<(), String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
 
         conn.execute(

--- a/app/src-tauri/src/core/transactions.rs
+++ b/app/src-tauri/src/core/transactions.rs
@@ -139,7 +139,7 @@ pub fn create_transaction_db(
 
 /// Retrieves all transactions for a specific account, ordered by date descending.
 pub fn get_transactions_db(db_path: &PathBuf, account_id: i32) -> Result<Vec<Transaction>, String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
 
         let mut stmt = conn.prepare("SELECT id, account_id, date, payee, notes, category, amount, ticker, shares, price_per_share, fee, currency FROM transactions WHERE account_id = ?1 ORDER BY date DESC, id DESC").map_err(|e| e.to_string())?;
@@ -699,7 +699,7 @@ pub fn update_investment_transaction_db(
 
 /// Deletes a transaction, reverts its account balance, and removes any linked transfer counterpart.
 pub fn delete_transaction_db(db_path: &PathBuf, id: i32) -> Result<(), String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let mut conn = Connection::open(db_path).map_err(|e| e.to_string())?;
 
         let tx = conn.transaction().map_err(|e| e.to_string())?;

--- a/app/src-tauri/src/core/utils.rs
+++ b/app/src-tauri/src/core/utils.rs
@@ -115,7 +115,7 @@ pub fn set_custom_exchange_rate_db(
     currency: String,
     rate: f64,
 ) -> Result<(), String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
         conn.execute(
             "INSERT OR REPLACE INTO custom_exchange_rates (currency, rate) VALUES (?1, ?2)",
@@ -132,7 +132,7 @@ pub fn get_custom_exchange_rate_db(
     db_path: &PathBuf,
     currency: String,
 ) -> Result<Option<f64>, String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
 
         let mut stmt = conn
@@ -393,7 +393,7 @@ fn get_account_currencies(db_path: &PathBuf) -> Result<Vec<String>, String> {
 
 /// Delete a custom exchange rate from the database
 pub fn delete_custom_exchange_rate_db(db_path: &PathBuf, currency: String) -> Result<(), String> {
-    crate::db_init::with_db_lock(db_path, || {
+    crate::db_init::with_db_lock(db_path, move || {
         let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
         conn.execute(
             "DELETE FROM custom_exchange_rates WHERE currency = ?1",


### PR DESCRIPTION
CodeQL's Rust analysis does not track closure variable captures, causing it to flag function parameters as unused when they are only referenced inside a `|| {}` closure passed to `with_db_lock`. Switching to `move || {}` makes the captures explicit in the syntax, resolving all 24 alerts across accounts.rs, llm.rs, markets.rs, rules.rs, scheduled.rs, transactions.rs, and utils.rs.

For Tauri command functions where `db_path` is a local owned `PathBuf` (and cannot be moved while also borrowed by the outer call), a `&Path` reference is extracted first so the `move` closure can copy it.